### PR TITLE
Make duplicate checking less restrictive by adding age checking

### DIFF
--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -116,7 +116,8 @@ public class Person {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName());
+                && otherPerson.getName().equals(getName())
+                && otherPerson.getAge().equals(getAge());
     }
 
     /**


### PR DESCRIPTION
Two students are considered duplicates only if their names are exact matches (john doe and John  Doe are still considered different names) and their ages are the same. A warning is still shown if the user adds a student with the exact same name but different age along with a list of similar persons.

### Instructions for testing
1. Enter the command `add n\John Doe a\11 ....`
2. Enter the command `add n\John Doe a\7....`
Expected: John Doe aged 7 is added. A duplicate warning is shown in the message bar. A list of similar persons including John Doe aged 11 is shown.

I'm wondering if this would still be considered too restrictive. One of the testers suggested checking by parent name, but I don't think that's a very good idea as students can have multiple parents lol.

Closes #209 
Closes #195